### PR TITLE
Update migration task

### DIFF
--- a/src/Task/FluentMigrationTask.php
+++ b/src/Task/FluentMigrationTask.php
@@ -73,7 +73,7 @@ class FluentMigrationTask extends BuildTask
         ]
 
     ];
-    protected $dryRun = false;
+    protected $write = false;
     protected $migrate_sublcasses_of = DataObject::class;
 
     /**
@@ -81,6 +81,8 @@ class FluentMigrationTask extends BuildTask
      */
     public function run($request)
     {
+        $this->write = ($request->getVar('write') === 'true');
+
         $queries = $this->buildQueries();
         $this->runQueries($queries);
     }
@@ -227,7 +229,7 @@ class FluentMigrationTask extends BuildTask
 
             foreach ($localeQueries as $table => $query) {
                 echo "Updating table '{$table}'\n";
-                if ($this->dryRun === false) {
+                if ($this->write === true) {
                     try {
                         DB::query($query);
                     } catch (DatabaseException $e) {

--- a/src/Task/FluentMigrationTask.php
+++ b/src/Task/FluentMigrationTask.php
@@ -140,8 +140,8 @@ class FluentMigrationTask extends BuildTask
                     foreach ($suffixes as $suffix) {
                         $localisedTable = "{$table}_Localised{$suffix}";
                         $sourceTable = "{$table}{$suffix}";
-                        $selectFields = $this->buildSelectFieldList($fields, $locale);
-                        $updateFields = $this->buildUpdateFieldList($fields, $locale);
+                        $selectFields = $this->buildSelectFieldList($sourceTable, $fields, $locale);
+                        $updateFields = $this->buildUpdateFieldList($sourceTable, $fields, $locale);
                         if ($suffix === '_Versions') {
                             $versionSelector = 'Version,';
                             $idField = 'RecordID';
@@ -188,13 +188,13 @@ class FluentMigrationTask extends BuildTask
      * @param $locale
      * @return string
      */
-    protected function buildSelectFieldList($fields, $locale)
+    protected function buildSelectFieldList($sourceTable, $fields, $locale)
     {
         return implode(
             ', ',
             array_map(
-                function ($field) use ($locale) {
-                    return sprintf('`%s_%s` AS `%s`', $field, $locale, $field);
+                function ($field) use ($locale, $sourceTable) {
+                    return sprintf('COALESCE(`%s_%s`, `%s`.`%s`) AS `%s`', $field, $locale, $sourceTable, $field, $field);
                 },
                 $fields
             )
@@ -206,13 +206,13 @@ class FluentMigrationTask extends BuildTask
      * @param $locale
      * @return string
      */
-    protected function buildUpdateFieldList($fields, $locale)
+    protected function buildUpdateFieldList($sourceTable, $fields, $locale)
     {
         return implode(
             ', ',
             array_map(
-                function ($field) use ($locale) {
-                    return sprintf('`%s` = `%s_%s`', $field, $field, $locale);
+                function ($field) use ($locale, $sourceTable) {
+                    return sprintf('`%s` = COALESCE(`%s_%s`, `%s`.`%s`)', $field, $field, $locale, $sourceTable, $field);
                 },
                 $fields
             )

--- a/tests/php/Task/FluentMigrationTaskTest.php
+++ b/tests/php/Task/FluentMigrationTaskTest.php
@@ -352,6 +352,28 @@ class FluentMigrationTaskTest extends SapphireTest
         $this->assertEquals('idiot box', $row['Name']);
     }
 
+    public function testMigrationTaskDoesNotCreateRecordIfNoTranslationsExist()
+    {
+        Config::modify()->set('Fluent', 'locales', ['en_US', 'de_AT']);
+
+        $partiallyTranslated = $this->objFromFixture(TranslatedDataObject::class, 'partiallyTranslated');
+
+        $this->assertFalse($this->hasLocalisedRecord($partiallyTranslated, 'de_AT'),
+            'partiallyTranslated should not exist in locale de_AT before migration');
+        $this->assertFalse($this->hasLocalisedRecord($partiallyTranslated, 'en_US'),
+            'partiallyTranslated should not exist in locale en_US before migration');
+
+        $task = FluentMigrationTask::create();
+        $task->setMigrateSubclassesOf(TranslatedDataObject::class);
+
+        $task->run($this->getRequest());
+
+        $this->assertTrue($this->hasLocalisedRecord($partiallyTranslated, 'de_AT'),
+            'partiallyTranslated should exist in locale de_AT after migration');
+        $this->assertFalse($this->hasLocalisedRecord($partiallyTranslated, 'en_US'),
+            'partiallyTranslated should not exist in locale en_US after migration');
+    }
+
     /**
      * Check if a localised record exists for the given locale
      *

--- a/tests/php/Task/FluentMigrationTaskTest.yml
+++ b/tests/php/Task/FluentMigrationTaskTest.yml
@@ -22,6 +22,11 @@ TractorCow\Fluent\Tests\Task\FluentMigrationTaskTest\TranslatedDataObject:
     Title_de_AT: 'Fernseher'
     Name: 'big flatscreen'
     Name_de_AT: 'Flachbild (groß)'
+  fragmented:
+    Title: 'TV'
+    Title_de_AT: 'Fernseher'
+    Name: 'big flatscreen'
+    Name_en_US: 'idiot box'
 
 TractorCow\Fluent\Tests\Task\FluentMigrationTaskTest\TranslatedDataObjectSubclass:
   tree:

--- a/tests/php/Task/FluentMigrationTaskTest.yml
+++ b/tests/php/Task/FluentMigrationTaskTest.yml
@@ -22,6 +22,9 @@ TractorCow\Fluent\Tests\Task\FluentMigrationTaskTest\TranslatedDataObject:
     Title_de_AT: 'Fernseher'
     Name: 'big flatscreen'
     Name_de_AT: 'Flachbild (groß)'
+  unTranslated:
+    Title: 'TV'
+    Name: 'big flatscreen'
   fragmented:
     Title: 'TV'
     Title_de_AT: 'Fernseher'


### PR DESCRIPTION
Updates the task with the following changes:

Remove the `dryRun` flag and replace it with a `write` parameter. This means that writing can be enabled by passing `write=true` to the task on the command line.

When only some fields have a translation, copy the default value for blank fields. This mimics the SS3 behaviour which falls back to default. In the SS4 version if an individual translated field is `null` then it does not fall back to the default and results in a blank value.

Don't create a row in the `Localised` table if there are _no_ translated fields for a locale _unless_ it is the default locale.