### PR TITLE
Handle missing fields in V3 -> v4 migration

### DIFF
--- a/src/Task/FluentMigrationTask.php
+++ b/src/Task/FluentMigrationTask.php
@@ -155,10 +155,10 @@ class FluentMigrationTask extends BuildTask
 
             foreach ($tableFields as $table => $fields) {
                 if (count($fields) > 0) {
-                    $existingFields = $this->getExistingFields($table);
                     foreach ($suffixes as $suffix) {
                         $localisedTable = "{$table}_Localised{$suffix}";
                         $sourceTable = "{$table}{$suffix}";
+                        $existingFields = $this->getExistingFields($sourceTable);
                         $selectFields = $this->buildSelectFieldList($sourceTable, $fields, $locale, $existingFields);
                         $updateFields = $this->buildUpdateFieldList($sourceTable, $fields, $locale, $existingFields);
                         $whereClause = ($locale == $this->getDefaultLocale())

--- a/src/Task/FluentMigrationTask.php
+++ b/src/Task/FluentMigrationTask.php
@@ -155,14 +155,15 @@ class FluentMigrationTask extends BuildTask
 
             foreach ($tableFields as $table => $fields) {
                 if (count($fields) > 0) {
+                    $existingFields = $this->getExistingFields($table);
                     foreach ($suffixes as $suffix) {
                         $localisedTable = "{$table}_Localised{$suffix}";
                         $sourceTable = "{$table}{$suffix}";
-                        $selectFields = $this->buildSelectFieldList($sourceTable, $fields, $locale);
-                        $updateFields = $this->buildUpdateFieldList($sourceTable, $fields, $locale);
+                        $selectFields = $this->buildSelectFieldList($sourceTable, $fields, $locale, $existingFields);
+                        $updateFields = $this->buildUpdateFieldList($sourceTable, $fields, $locale, $existingFields);
                         $whereClause = ($locale == $this->getDefaultLocale())
                             ? ''
-                            : $this->buildWhere($fields, $locale);
+                            : $this->buildWhere($fields, $locale, $existingFields);
                         if ($suffix === '_Versions') {
                             $versionSelector = 'Version,';
                             $idField = 'RecordID';
@@ -206,17 +207,37 @@ class FluentMigrationTask extends BuildTask
     }
 
     /**
+     * Return the fields that actually exist on a table
+     *
+     * @param string $table
+     * @return array
+     */
+    protected function getExistingFields($table)
+    {
+        $query = sprintf("SHOW COLUMNS from %s", $table);
+        try {
+            return DB::query($query)->column('Field');
+        } catch(\Exception $ex) {
+            return [];
+        }
+    }
+
+    /**
      * @param $fields
      * @param $locale
      * @return string
      */
-    protected function buildSelectFieldList($sourceTable, $fields, $locale)
+    protected function buildSelectFieldList($sourceTable, $fields, $locale, $existingFields)
     {
         return implode(
             ', ',
             array_map(
-                function ($field) use ($locale, $sourceTable) {
-                    return sprintf('COALESCE(`%s_%s`, `%s`.`%s`) AS `%s`', $field, $locale, $sourceTable, $field, $field);
+                function ($field) use ($locale, $sourceTable, $existingFields) {
+                    return sprintf(
+                        '%s AS `%s`',
+                        $this->buildCoalesce($sourceTable, $field, $locale, $existingFields),
+                        $field
+                    );
                 },
                 $fields
             )
@@ -228,39 +249,74 @@ class FluentMigrationTask extends BuildTask
      * @param $locale
      * @return string
      */
-    protected function buildUpdateFieldList($sourceTable, $fields, $locale)
+    protected function buildUpdateFieldList($sourceTable, $fields, $locale, $existingFields)
     {
         return implode(
             ', ',
             array_map(
-                function ($field) use ($locale, $sourceTable) {
-                    return sprintf('`%s` = COALESCE(`%s_%s`, `%s`.`%s`)', $field, $field, $locale, $sourceTable, $field);
+                function ($field) use ($locale, $sourceTable, $existingFields) {
+                    return sprintf(
+                        '`%s` = %s',
+                        $field,
+                        $this->buildCoalesce($sourceTable, $field, $locale, $existingFields)
+                    );
                 },
                 $fields
             )
         );
+    }
+
+    /**
+     * Build a SQL `COALESCE` statement using null if the translated field
+     * doesn't exist
+     *
+     * @param string $sourceTable
+     * @param string $field
+     * @param string $locale
+     * @param array $existingFields
+     * @return string
+     */
+    protected function buildCoalesce($sourceTable, $field, $locale, $existingFields)
+    {
+        $localeField = sprintf('%s_%s', $field, $locale);
+        if (in_array($localeField, $existingFields)) {
+            $localeField = "`$localeField`";
+        } else {
+            $localeField = 'null';
+        }
+        return sprintf('COALESCE(%s, `%s`.`%s`)', $localeField, $sourceTable, $field);
     }
 
     /**
      * Build a where clause to ensure we only get locales that have translations
-     * for one or more fields
+     * for one or more fields. Skip any translated fields that don't exist in the
+     * source table.
      *
      * @param string $sourceTable
      * @param array $fields
      * @param string $locale
      * @return string
      */
-    protected function buildWhere($fields, $locale)
+    protected function buildWhere($fields, $locale, $existingFields)
     {
+        $localeFields = array_map(
+            function($field) use($locale) { return sprintf('%s_%s', $field, $locale); },
+            $fields
+        );
+        $validFields = array_intersect($localeFields, $existingFields);
         $whereFields = implode(
             ' OR ',
             array_map(
                 function ($field) use ($locale) {
-                    return sprintf('`%s_%s` IS NOT NULL', $field, $locale);
+                    return sprintf('`%s` IS NOT NULL', $field, $locale);
                 },
-                $fields
+                $validFields
             )
         );
+        // Skip if no translation fields exist
+        if ($whereFields === '') {
+            $whereFields = 'false';
+        }
         return "WHERE ({$whereFields})";
     }
 

--- a/tests/php/Task/FluentMigrationTaskTest.php
+++ b/tests/php/Task/FluentMigrationTaskTest.php
@@ -465,11 +465,11 @@ class FluentMigrationTaskTest extends SapphireTest
 
         $this->assertTrue(
             $this->hasLocalisedRecord($unTranslated, 'en_US'),
-            'unTranslated should not exist in locale en_US after migration'
+            'unTranslated should exist in locale en_US after migration'
         );
         $this->assertFalse(
             $this->hasLocalisedRecord($unTranslated, 'de_AT'),
-            'unTranslated should exist in locale de_AT after migration'
+            'unTranslated should not exist in locale de_AT after migration'
         );
     }
 

--- a/tests/php/Task/FluentMigrationTaskTest.yml
+++ b/tests/php/Task/FluentMigrationTaskTest.yml
@@ -43,6 +43,19 @@ TractorCow\Fluent\Tests\Task\FluentMigrationTaskTest\TranslatedDataObjectSubclas
     Category_en_US: 'deciduous trees'
     Category_de_AT: 'Laubbäume'
 
+TractorCow\Fluent\Tests\Task\FluentMigrationTaskTest\TranslatedDataObjectPartialSubclass:
+  dog:
+    Title: 'A Dog'
+    Title_en_US: 'A Dog'
+    Title_de_AT: 'Ein Hund'
+    Name: 'Sheepdog'
+    Name_en_US: 'Sheepdog'
+    Name_de_AT: 'Schäferhund'
+    Category: 'working dogs'
+    Category_en_US: 'working dogs'
+    Category_de_AT: 'Arbeitshunde'
+    Colour: 'Brown'
+
 TractorCow\Fluent\Tests\Task\FluentMigrationTaskTest\TranslatedPage:
   table:
     Title: 'A Table'

--- a/tests/php/Task/FluentMigrationTaskTest/TranslatedDataObjectPartialSubclass.php
+++ b/tests/php/Task/FluentMigrationTaskTest/TranslatedDataObjectPartialSubclass.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace TractorCow\Fluent\Tests\Task\FluentMigrationTaskTest;
+
+
+class TranslatedDataObjectPartialSubclass extends TranslatedDataObject
+{
+    private static $db = [
+        'Category' => 'Varchar',
+        'Colour' => 'Varchar',
+    ];
+
+    private static $table_name = 'FluentTestDataObjectPartialSubclass';
+
+    /**
+     * @var array
+     */
+    private static $old_fluent_fields = [
+        'Category_en_US',
+        'Category_de_AT',
+    ];
+}


### PR DESCRIPTION
This handles translation fields that might not exist in the source table because Fluent now by default classifies a wider range of fields as translatable than in did in the SS3 version.